### PR TITLE
댓글 관련 URL 변경 및 Mapper.xml의 countReplyByPost 오류 수정

### DIFF
--- a/src/main/java/com/gatheringplatform/controller/ReplyController.java
+++ b/src/main/java/com/gatheringplatform/controller/ReplyController.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 @CrossOrigin(origins = "*", allowedHeaders = "*")
 @RestController // JSON 형태로 객체 데이터를 반환하기 위한 컨트롤러
-@RequestMapping(value = "/board/{board_id}")
+@RequestMapping(value = "/board/{board_id}/reply")
 public class ReplyController {
 
     @Autowired

--- a/src/main/java/com/gatheringplatform/service/ReplyServiceImpl.java
+++ b/src/main/java/com/gatheringplatform/service/ReplyServiceImpl.java
@@ -40,14 +40,14 @@ public class ReplyServiceImpl implements ReplyService {
     }
 
     @Override
-    public List<Reply> viewAll(long post_id, long page_num) { // 해당 게시물의 전체 댓글 목록 반환
+    public List<Reply> viewAll(long post_id, long pageNum) { // 해당 게시물의 전체 댓글 목록 반환
 
         // 해당 페이지가 존재하지 않을때
-        if (page_num == 0) {
+        if (pageNum == 0) {
             throw new RequestException(ErrorEnum.NON_EXISTED_PAGE);
         }
 
-        long startIndex = (page_num - 1) * 5;
+        long startIndex = (pageNum - 1) * 5;
 
         // DB에 담겨진 인덱스를 초과한 페이지를 요청했을 때
         if (replyMapper.countReplyByPost(post_id) < startIndex) {

--- a/src/main/resources/mappers/replyMapper.xml
+++ b/src/main/resources/mappers/replyMapper.xml
@@ -14,8 +14,8 @@
                created_at,
                is_deleted
         FROM post_reply
-        WHERE post_id = #{post_id}
-        AND is_deleted = false
+        WHERE is_deleted = false
+        AND post_id = #{post_id}
         ORDER BY parent_id
         LIMIT #{startIndex}, 5
     </select>
@@ -30,7 +30,7 @@
         FROM post_reply
         WHERE id = #{id}
     </select>
-    <select id="countReplyByPost" parameterType="string" resultType="long">
+    <select id="countReplyByPost" parameterType="long" resultType="long">
         SELECT COUNT(*)
         FROM post_reply
         WHERE post_id = #{post_id}


### PR DESCRIPTION
board와 URL이 겹쳐 생기는 문제를 해결하였고, countReplyByPost의 required type을 string에서 int로 수정하여 코드가 정상 작동하게 하였습니다. 제 로컬에서 테스트를 통과했습니다.